### PR TITLE
Fix symbolic links for bash

### DIFF
--- a/src/wireguard/setup_wireguard.sh
+++ b/src/wireguard/setup_wireguard.sh
@@ -11,7 +11,8 @@ WIREGUARD="/mnt/data/wireguard"
 
 ln -sf $WIREGUARD/usr/bin/wg-quick /usr/bin
 ln -sf $WIREGUARD/usr/bin/wg /usr/bin
-ln -sf $WIREGUARD/usr/bin/bash /usr/bin /bin
+ln -sf $WIREGUARD/usr/bin/bash /usr/bin
+ln -sf $WIREGUARD/usr/bin/bash /bin
 ln -sf $WIREGUARD/usr/bin/qrencode /usr/bin
 ln -sf $WIREGUARD/usr/bin/htop /usr/bin
 ln -sf $WIREGUARD/usr/sbin/iftop /usr/sbin


### PR DESCRIPTION
My mistake, I meant to link bash to both /usr/bin/bash and /bin/bash since a lot of scripts use /bin/bash by default. 